### PR TITLE
Add origin parameter, `parent` check, and return status to handleRedirect

### DIFF
--- a/src/oauth2.popup.mjs
+++ b/src/oauth2.popup.mjs
@@ -7,7 +7,9 @@
  * opener window must have a strict match with the origin of the
  * popup page.
  */
-export function handleRedirect() {
+export function handleRedirect(origin = null) {
+	origin = origin || window.location.origin
+
 	let params = new URLSearchParams(window.location.search)
 	if (!params.has('code') && window.location.hash) {
 		let query = window.location.hash.substr(1)
@@ -17,15 +19,15 @@ export function handleRedirect() {
 	if (params.has('code')) {
 		parent.postMessage({
 			authorization_code: params.get('code')
-		}, window.location.origin)
+		}, origin)
 	} else if (params.has('error')) {
 		parent.postMessage({
 			error: params.get('error')
-		}, window.location.origin)
+		}, origin)
 	} else {
 		parent.postMessage({
 			error: 'Could not find an authorization_code'
-		}, window.location.origin)
+		}, origin)
 	}
 }
 

--- a/src/oauth2.popup.mjs
+++ b/src/oauth2.popup.mjs
@@ -8,6 +8,8 @@
  * popup page.
  */
 export function handleRedirect(origin = null) {
+	let success = false
+
 	origin = origin || window.location.origin
 
 	let params = new URLSearchParams(window.location.search)
@@ -15,20 +17,29 @@ export function handleRedirect(origin = null) {
 		let query = window.location.hash.substr(1)
 		params = new URLSearchParams('?'+query)
 	}
+
 	let parent = (window.parent !== window) ? window.parent : window.opener
-	if (params.has('code')) {
-		parent.postMessage({
-			authorization_code: params.get('code')
-		}, origin)
-	} else if (params.has('error')) {
-		parent.postMessage({
-			error: params.get('error')
-		}, origin)
+	if (! parent) {
+		// There is no parent, either the page was opened directly or the user closed the calling window.
+		console.error('No parent window found, cannot post authorization code (or error)')
 	} else {
-		parent.postMessage({
-			error: 'Could not find an authorization_code'
-		}, origin)
+		if (params.has('code')) {
+			parent.postMessage({
+				authorization_code: params.get('code')
+			}, origin)
+			success = true
+		} else if (params.has('error')) {
+			parent.postMessage({
+				error: params.get('error')
+			}, origin)
+		} else {
+			parent.postMessage({
+				error: 'Could not find an authorization_code',
+			}, origin)
+		}
 	}
+
+	return success
 }
 
 /**


### PR DESCRIPTION
This MR makes it possible for the origin to be set from outside the `handleRedirect()` function, by passing it in as a parameter. It defaults to the existing `window.location.origin`.

It also introduces a return variable, denoting whether the redirect was successful (i.e. received an authorization code) or not.

Finally, a check has been added to not try to post to a parent, if no such parent exists. (This will log an error, but not throw an exception.